### PR TITLE
🔧 Add pip_requirements manager to Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended", ":gitSignOff", "helpers:pinGitHubActionDigests"],
   prHourlyLimit: 10,
-  enabledManagers: ["github-actions", "pre-commit"],
+  enabledManagers: ["github-actions", "pip_requirements", "pre-commit"],
   "pre-commit": {
     enabled: true
   },
@@ -14,6 +14,11 @@
       matchManagers: ["github-actions"],
       addLabels: ["github-actions"],
       commitMessagePrefix: "⬆\uFE0F\uD83D\uDC68\u200D\uD83D\uDCBB"
+    },
+    {
+      matchManagers: ["pip_requirements"],
+      addLabels: ["python"],
+      commitMessagePrefix: "⬆\uFE0F\uD83D\uDC0D"
     },
     {
       matchManagers: ["pre-commit"],


### PR DESCRIPTION
This PR adds the [`pip_requirements`](https://docs.renovatebot.com/modules/manager/pip_requirements/) manager to the Renovate config so that `docs/requirements.txt` is maintained.

After this and the upcoming Renovate PRs are merged, #40 should be fixed.