### PR TITLE
📌 Add lower bound for `sphinx-llm`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,7 +17,7 @@ qiskit[visualization]>=1.0.0
 sphinx>=8.1.3; python_version >= '3.10'
 sphinx>=8.2.3; python_version >= '3.11'
 sphinx-copybutton>=0.5.2
-sphinx-llm
+sphinx-llm>=0.4.1
 sphinx_design>=0.6.1
 sphinxcontrib-bibtex>=2.6.3
 sphinxcontrib-svg2pdfconverter>=1.2.3


### PR DESCRIPTION
## Description

This PR adds a lower bound for `sphinx-llm`, after I forgot to do so in #182.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/.github/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
